### PR TITLE
fix: apply DEV_BYPASS_AUTH check in proxy to prevent redirect loop

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -35,6 +35,9 @@ export async function proxy(request: NextRequest) {
   const isPublic = PUBLIC_PATHS.some((p) => path === p || path.startsWith('/parent/'))
   if (isPublic) return supabaseResponse
 
+  // Dev bypass — skip auth check locally
+  if (process.env.DEV_BYPASS_AUTH === 'true') return supabaseResponse
+
   // Protect app routes
   if (!user) {
     const url = request.nextUrl.clone()


### PR DESCRIPTION
Server.ts bypass didn't cover the middleware, causing / → /library → / infinite loop.

**Description**
Fixes an infinite redirect loop caused by the DEV_BYPASS_AUTH flag not being applied in the middleware (proxy.ts).
  When the bypass was enabled, / redirected to /library, but the proxy had no session and redirected straight back to
  /. Added the bypass check to proxy.ts so authenticated routes are allowed through when DEV_BYPASS_AUTH=true.