### PR TITLE
Add share link feature for sent conversations

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -8,6 +8,9 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=
 
 # Dev bypass — set DEV_BYPASS_AUTH=true to skip auth locally
+# DEV_USER_ID: your user ID from Supabase dashboard → Authentication → Users
+# SUPABASE_SERVICE_ROLE_KEY: Supabase dashboard → Project Settings → Data API → service_role secret
 DEV_BYPASS_AUTH=false
 DEV_USER_ID=
 DEV_USER_EMAIL=
+SUPABASE_SERVICE_ROLE_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+## Database rules
+
+- Every new Supabase table must have RLS policies for SELECT, INSERT, and UPDATE
+- Always use `auth.uid() = user_id` pattern
+- Never create a table without corresponding policies

--- a/app/(app)/conversations/page.tsx
+++ b/app/(app)/conversations/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from '@/src/lib/supabase/server'
 import topicsData from '@/src/data/topics.json'
 import { Topic } from '@/src/lib/types'
 import { Badge } from '@/src/components/ui/Badge'
+import { CopyLinkButton } from '@/src/components/CopyLinkButton'
 
 const topics = topicsData as Topic[]
 
@@ -120,12 +121,15 @@ export default async function ConversationsPage() {
                     View responses →
                   </Link>
                 ) : (
-                  <span
-                    className="text-xs font-mono px-2.5 py-1 rounded-xl border whitespace-nowrap"
-                    style={{ borderColor: '#e5ddd5', color: '#6b5e52', background: '#f6f3ef' }}
-                  >
-                    {conv.access_code}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="text-xs font-mono px-2.5 py-1 rounded-xl border whitespace-nowrap"
+                      style={{ borderColor: '#e5ddd5', color: '#6b5e52', background: '#f6f3ef' }}
+                    >
+                      {conv.access_code}
+                    </span>
+                    {conv.access_code && <CopyLinkButton code={conv.access_code} />}
+                  </div>
                 )}
               </div>
             )

--- a/app/(app)/library/[topicId]/actions.ts
+++ b/app/(app)/library/[topicId]/actions.ts
@@ -1,0 +1,30 @@
+'use server'
+
+import { createClient } from '@/src/lib/supabase/server'
+import { revalidatePath } from 'next/cache'
+
+export async function sendConversation(payload: {
+  relationshipId: string
+  topicId: string
+  code: string
+}) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const { error } = await supabase.from('conversations').upsert(
+    {
+      user_id: user.id,
+      relationship_id: payload.relationshipId,
+      topic_id: payload.topicId,
+      status: 'sent',
+      access_code: payload.code,
+      sent_at: new Date().toISOString(),
+    },
+    { onConflict: 'user_id,topic_id,relationship_id' },
+  )
+
+  if (error) return { error: error.message }
+  revalidatePath(`/library/${payload.topicId}`)
+  return { error: null }
+}

--- a/app/(app)/library/[topicId]/client.tsx
+++ b/app/(app)/library/[topicId]/client.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/src/components/ui/Badge";
 import { Button } from "@/src/components/ui/Button";
 import topicsData from "@/src/data/topics.json";
 import { createClient } from "@/src/lib/supabase/client";
+import { sendConversation } from "./actions";
 import { Relationship, Topic } from "@/src/lib/types";
 import { StaticStoryPreview } from "@/src/mad-lib-death/StaticStoryPreview";
 import { TweeStory } from "@/src/mad-lib-death/parse-twee";
@@ -12,6 +13,41 @@ import { track } from "@vercel/analytics";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+
+const PARENT_BASE_URL = "https://app.ourhearth.co/parent";
+
+function CopyLinkInline({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  async function handleCopy() {
+    await navigator.clipboard.writeText(`${PARENT_BASE_URL}?code=${code}`);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+  return (
+    <button
+      onClick={handleCopy}
+      title="Copy link"
+      className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1.5 rounded-xl border transition-colors whitespace-nowrap"
+      style={{
+        borderColor: copied ? "#059669" : "#6ee7b7",
+        color: copied ? "#059669" : "#065f46",
+        background: copied ? "#d1fae5" : "#f0fdf4",
+      }}
+    >
+      {copied ? (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+      {copied ? "Copied!" : "Copy link"}
+    </button>
+  );
+}
 
 const topics = topicsData as Topic[];
 
@@ -45,9 +81,13 @@ function generateCode(): string {
 export default function TopicDetailClient({
   topicId,
   story,
+  relationships,
+  userId,
 }: {
   topicId: string;
   story: TweeStory | null;
+  relationships: Relationship[];
+  userId: string;
 }) {
   const topic = topics.find((t) => t.id === topicId);
   const router = useRouter();
@@ -74,17 +114,15 @@ export default function TopicDetailClient({
   ];
 
   async function fetchPastConvs() {
+    if (!userId) return;
     const supabase = createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return;
-    console.log("fetchPastConvs user.id:", user.id);
     const { data } = await supabase
       .from("conversations")
       .select(
         "id, status, sent_at, access_code, choices, relationships(display_name)",
       )
       .eq("topic_id", topicId)
-      .eq("user_id", user.id)
+      .eq("user_id", userId)
       .neq("status", "draft")
       .order("created_at", { ascending: false });
     setPastConvs((data as unknown as ConvRow[]) ?? []);
@@ -110,70 +148,48 @@ export default function TopicDetailClient({
     );
   }
 
-  async function handleSend(relationships: Relationship[]) {
+  async function handleSend(rels: Relationship[]) {
     setShowPicker(false);
 
+    // Check for existing conversations (anon policy allows this read)
     const supabase = createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return;
-
-    // Check for existing conversations for any of the selected relationships
     const { data: existing } = await supabase
       .from("conversations")
       .select("relationship_id, status")
       .eq("topic_id", topic!.id)
-      .eq("user_id", user.id)
-      .in(
-        "relationship_id",
-        relationships.map((r) => r.id),
-      );
+      .eq("user_id", userId)
+      .in("relationship_id", rels.map((r) => r.id));
 
     const conflicts = (existing ?? [])
       .map((row) => ({
-        rel: relationships.find((r) => r.id === row.relationship_id)!,
+        rel: rels.find((r) => r.id === row.relationship_id)!,
         status: row.status as string,
       }))
       .filter((c) => c.rel != null);
 
     if (conflicts.length > 0) {
-      setOverwriteWarning({ pendingRelationships: relationships, conflicts });
+      setOverwriteWarning({ pendingRelationships: rels, conflicts });
       return;
     }
 
-    await doSend(relationships, supabase, user.id);
+    await doSend(rels);
   }
 
-  async function doSend(
-    relationships: Relationship[],
-    supabase: ReturnType<typeof createClient>,
-    userId: string,
-  ) {
+  async function doSend(rels: Relationship[]) {
     setOverwriteWarning(null);
     setSending(true);
 
     const codes: string[] = [];
 
-    for (const rel of relationships) {
+    for (const rel of rels) {
       const code = generateCode();
-      await supabase.from("conversations").upsert(
-        {
-          user_id: userId,
-          relationship_id: rel.id,
-          topic_id: topic!.id,
-          status: "sent",
-          access_code: code,
-          sent_at: new Date().toISOString(),
-        },
-        { onConflict: "user_id,topic_id,relationship_id" },
-      );
+      await sendConversation({ relationshipId: rel.id, topicId: topic!.id, code });
       codes.push(code);
     }
 
     setSentCode({
       code: codes.join(", "),
-      label: relationships.map((r) => r.display_name).join(", "),
+      label: rels.map((r) => r.display_name).join(", "),
     });
     setSending(false);
     fetchPastConvs();
@@ -181,12 +197,7 @@ export default function TopicDetailClient({
 
   async function handleOverwriteConfirm() {
     if (!overwriteWarning) return;
-    const supabase = createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return;
-    await doSend(overwriteWarning.pendingRelationships, supabase, user.id);
+    await doSend(overwriteWarning.pendingRelationships);
   }
 
   return (
@@ -197,6 +208,7 @@ export default function TopicDetailClient({
           onClose={() => setShowPicker(false)}
           storyId={topicId}
           storyTitle={topic.title}
+          relationships={relationships}
         />
       )}
 
@@ -343,22 +355,26 @@ export default function TopicDetailClient({
                   Sent to {sentCode.label} ✓
                 </p>
                 <p className="text-xs mb-2" style={{ color: "#065f46" }}>
-                  Share this code with them:
+                  Share this link with your parent:
                 </p>
-                <p
-                  className="text-2xl font-bold tracking-widest"
-                  style={{ color: "#1a1512" }}
-                >
-                  {sentCode.code}
-                </p>
-                <p className="text-xs mt-2" style={{ color: "#6b5e52" }}>
-                  Tell your parent to go to{" "}
-                  <span className="font-bold">app.ourhearth.co/parent</span> to
-                  start the conversation.
+                <div className="flex items-center gap-2 mb-2">
+                  <input
+                    readOnly
+                    value={`app.ourhearth.co/parent?code=${sentCode.code}`}
+                    onFocus={(e) => e.target.select()}
+                    className="text-xs font-mono px-2.5 py-1.5 rounded-xl border flex-1 min-w-0 outline-none cursor-text"
+                    style={{ background: "#f0fdf4", borderColor: "#6ee7b7", color: "#065f46" }}
+                  />
+                  <CopyLinkInline code={sentCode.code} />
+                </div>
+                <p className="text-xs" style={{ color: "#6b5e52" }}>
+                  Share via WhatsApp, email, or any messaging app.
                 </p>
                 <p className="text-xs mt-1" style={{ color: "#9a8a7d" }}>
-                  Email sending coming soon. Share this code with your parent
-                  directly for now.
+                  Or they can visit{" "}
+                  <span className="font-bold">app.ourhearth.co/parent</span> and
+                  enter code{" "}
+                  <span className="font-bold tracking-widest">{sentCode.code}</span>.
                 </p>
               </div>
             )}

--- a/app/(app)/library/[topicId]/page.tsx
+++ b/app/(app)/library/[topicId]/page.tsx
@@ -1,6 +1,7 @@
 import { parseTwee } from "@/src/mad-lib-death/parse-twee";
 import topicsData from "@/src/data/topics.json";
-import { Topic } from "@/src/lib/types";
+import { Relationship, Topic } from "@/src/lib/types";
+import { createClient } from "@/src/lib/supabase/server";
 import fs from "fs";
 import path from "path";
 import TopicDetailClient from "./client";
@@ -24,5 +25,14 @@ export default async function TopicDetailPage({
       )
     : null;
 
-  return <TopicDetailClient topicId={topicId} story={story} />;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  const { data } = await supabase
+    .from("relationships")
+    .select("*")
+    .eq("user_id", user?.id)
+    .order("created_at");
+  const relationships = (data ?? []) as Relationship[];
+
+  return <TopicDetailClient topicId={topicId} story={story} relationships={relationships} userId={user?.id ?? ''} />;
 }

--- a/app/(app)/relationships/actions.ts
+++ b/app/(app)/relationships/actions.ts
@@ -1,0 +1,30 @@
+'use server'
+
+import { createClient } from '@/src/lib/supabase/server'
+import { revalidatePath } from 'next/cache'
+
+export async function addRelationship(displayName: string, email: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const { error } = await supabase.from('relationships').insert({
+    user_id: user.id,
+    display_name: displayName,
+    email: email || '',
+  })
+
+  if (error) return { error: error.message }
+  revalidatePath('/relationships')
+  return { error: null }
+}
+
+export async function deleteRelationship(id: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+  const { error } = await supabase.from('relationships').delete().eq('id', id).eq('user_id', user.id)
+  if (error) return { error: error.message }
+  revalidatePath('/relationships')
+  return { error: null }
+}

--- a/app/(app)/relationships/client.tsx
+++ b/app/(app)/relationships/client.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useState } from 'react'
+import { Relationship } from '@/src/lib/types'
+import { Button } from '@/src/components/ui/Button'
+import { Card } from '@/src/components/ui/Card'
+import { addRelationship, deleteRelationship } from './actions'
+
+const QUICK_NAMES = ['Mom', 'Dad', 'Grandma', 'Grandpa', 'Partner']
+
+export function RelationshipsClient({ initial }: { initial: Relationship[] }) {
+  const [showForm, setShowForm] = useState(false)
+  const [displayName, setDisplayName] = useState('')
+  const [email, setEmail] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    if (!displayName) return
+    setSaving(true)
+    setError('')
+    const result = await addRelationship(displayName, email)
+    if (result.error) { setError(result.error); setSaving(false); return }
+    setDisplayName('')
+    setEmail('')
+    setShowForm(false)
+    setSaving(false)
+  }
+
+  async function handleDelete(id: string) {
+    await deleteRelationship(id)
+  }
+
+  return (
+    <div className="p-8 max-w-2xl">
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold" style={{ color: '#1a1512' }}>Relationships</h1>
+          <p className="text-sm mt-1" style={{ color: '#6b5e52' }}>People you can send conversations to</p>
+        </div>
+        <Button onClick={() => setShowForm(true)} size="sm">
+          + Add person
+        </Button>
+      </div>
+
+      {showForm && (
+        <Card className="p-6 mb-6 shadow-sm">
+          <h2 className="font-semibold mb-4" style={{ color: '#1a1512' }}>Add a person</h2>
+          <form onSubmit={handleAdd} className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              {QUICK_NAMES.map((name) => (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => setDisplayName(name)}
+                  className="px-3 py-1.5 rounded-full text-sm border transition-all"
+                  style={{
+                    background: displayName === name ? '#fde8c8' : 'transparent',
+                    borderColor: displayName === name ? '#f59e0b' : '#e5ddd5',
+                    color: displayName === name ? '#92400e' : '#6b5e52',
+                  }}
+                >
+                  {name}
+                </button>
+              ))}
+            </div>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="Name (e.g. Mom, Dad)"
+              className="w-full px-4 py-3 rounded-xl border text-sm outline-none"
+              style={{ borderColor: '#e5ddd5', background: '#f6f3ef' }}
+              required
+            />
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email (optional)"
+              className="w-full px-4 py-3 rounded-xl border text-sm outline-none"
+              style={{ borderColor: '#e5ddd5', background: '#f6f3ef' }}
+            />
+            {error && <p className="text-sm text-red-600">{error}</p>}
+            <div className="flex gap-3">
+              <Button type="submit" disabled={saving || !displayName} size="sm">
+                {saving ? 'Saving...' : 'Save'}
+              </Button>
+              <Button type="button" variant="ghost" size="sm" onClick={() => setShowForm(false)}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </Card>
+      )}
+
+      {initial.length === 0 ? (
+        <Card muted className="p-8 text-center">
+          <p className="text-sm mb-4" style={{ color: '#9a8a7d' }}>No relationships yet.</p>
+          <Button onClick={() => setShowForm(true)} size="sm">Add your first person</Button>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {initial.map((rel) => (
+            <Card key={rel.id} className="p-5 flex items-center justify-between shadow-sm">
+              <div>
+                <p className="font-semibold" style={{ color: '#1a1512' }}>{rel.display_name}</p>
+                {rel.email && <p className="text-sm mt-0.5" style={{ color: '#9a8a7d' }}>{rel.email}</p>}
+              </div>
+              <button
+                onClick={() => handleDelete(rel.id)}
+                className="text-xs underline"
+                style={{ color: '#c4a592' }}
+              >
+                Remove
+              </button>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/relationships/page.tsx
+++ b/app/(app)/relationships/page.tsx
@@ -34,7 +34,7 @@ export default function RelationshipsPage() {
 
     const supabase = createClient()
     const { data: { user } } = await supabase.auth.getUser()
-    if (!user) return
+    if (!user) { setSaving(false); return }
 
     const { error } = await supabase.from('relationships').insert({
       user_id: user.id,

--- a/app/(app)/relationships/page.tsx
+++ b/app/(app)/relationships/page.tsx
@@ -1,151 +1,16 @@
-'use client'
-
-import { useEffect, useState } from 'react'
-import { createClient } from '@/src/lib/supabase/client'
+import { createClient } from '@/src/lib/supabase/server'
 import { Relationship } from '@/src/lib/types'
-import { Button } from '@/src/components/ui/Button'
-import { Card } from '@/src/components/ui/Card'
+import { RelationshipsClient } from './client'
 
-export default function RelationshipsPage() {
-  const [relationships, setRelationships] = useState<Relationship[]>([])
-  const [loading, setLoading] = useState(true)
-  const [showForm, setShowForm] = useState(false)
-  const [displayName, setDisplayName] = useState('')
-  const [email, setEmail] = useState('')
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState('')
+export default async function RelationshipsPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  const { data } = await supabase
+    .from('relationships')
+    .select('*')
+    .eq('user_id', user?.id)
+    .order('created_at')
+  const relationships = (data ?? []) as Relationship[]
 
-  const QUICK_NAMES = ['Mom', 'Dad', 'Grandma', 'Grandpa', 'Partner']
-
-  async function fetchRelationships() {
-    const supabase = createClient()
-    const { data } = await supabase.from('relationships').select('*').order('created_at')
-    setRelationships(data ?? [])
-    setLoading(false)
-  }
-
-  useEffect(() => { fetchRelationships() }, [])
-
-  async function handleAdd(e: React.FormEvent) {
-    e.preventDefault()
-    if (!displayName) return
-    setSaving(true)
-    setError('')
-
-    const supabase = createClient()
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user) { setSaving(false); return }
-
-    const { error } = await supabase.from('relationships').insert({
-      user_id: user.id,
-      display_name: displayName,
-      email: email || '',
-    })
-
-    if (error) { setError(error.message); setSaving(false); return }
-
-    setDisplayName('')
-    setEmail('')
-    setShowForm(false)
-    setSaving(false)
-    fetchRelationships()
-  }
-
-  async function handleDelete(id: string) {
-    const supabase = createClient()
-    await supabase.from('relationships').delete().eq('id', id)
-    setRelationships((prev) => prev.filter((r) => r.id !== id))
-  }
-
-  return (
-    <div className="p-8 max-w-2xl">
-      <div className="mb-8 flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold" style={{ color: '#1a1512' }}>Relationships</h1>
-          <p className="text-sm mt-1" style={{ color: '#6b5e52' }}>People you can send conversations to</p>
-        </div>
-        <Button onClick={() => setShowForm(true)} size="sm">
-          + Add person
-        </Button>
-      </div>
-
-      {showForm && (
-        <Card className="p-6 mb-6 shadow-sm">
-          <h2 className="font-semibold mb-4" style={{ color: '#1a1512' }}>Add a person</h2>
-          <form onSubmit={handleAdd} className="space-y-4">
-            <div className="flex flex-wrap gap-2">
-              {QUICK_NAMES.map((name) => (
-                <button
-                  key={name}
-                  type="button"
-                  onClick={() => setDisplayName(name)}
-                  className="px-3 py-1.5 rounded-full text-sm border transition-all"
-                  style={{
-                    background: displayName === name ? '#fde8c8' : 'transparent',
-                    borderColor: displayName === name ? '#f59e0b' : '#e5ddd5',
-                    color: displayName === name ? '#92400e' : '#6b5e52',
-                  }}
-                >
-                  {name}
-                </button>
-              ))}
-            </div>
-            <input
-              type="text"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="Name (e.g. Mom, Dad)"
-              className="w-full px-4 py-3 rounded-xl border text-sm outline-none"
-              style={{ borderColor: '#e5ddd5', background: '#f6f3ef' }}
-              required
-            />
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="Email (optional)"
-              className="w-full px-4 py-3 rounded-xl border text-sm outline-none"
-              style={{ borderColor: '#e5ddd5', background: '#f6f3ef' }}
-            />
-            {error && <p className="text-sm text-red-600">{error}</p>}
-            <div className="flex gap-3">
-              <Button type="submit" disabled={saving || !displayName} size="sm">
-                {saving ? 'Saving...' : 'Save'}
-              </Button>
-              <Button type="button" variant="ghost" size="sm" onClick={() => setShowForm(false)}>
-                Cancel
-              </Button>
-            </div>
-          </form>
-        </Card>
-      )}
-
-      {loading ? (
-        <p className="text-sm" style={{ color: '#9a8a7d' }}>Loading...</p>
-      ) : relationships.length === 0 ? (
-        <Card muted className="p-8 text-center">
-          <p className="text-sm mb-4" style={{ color: '#9a8a7d' }}>No relationships yet.</p>
-          <Button onClick={() => setShowForm(true)} size="sm">Add your first person</Button>
-        </Card>
-      ) : (
-        <div className="space-y-3">
-          {relationships.map((rel) => (
-            <Card key={rel.id} className="p-5 flex items-center justify-between shadow-sm">
-              <div>
-                <p className="font-semibold" style={{ color: '#1a1512' }}>{rel.display_name}</p>
-                {rel.email && <p className="text-sm mt-0.5" style={{ color: '#9a8a7d' }}>{rel.email}</p>}
-              </div>
-              <button
-                onClick={() => handleDelete(rel.id)}
-                className="text-xs underline"
-                style={{ color: '#c4a592' }}
-              >
-                Remove
-              </button>
-            </Card>
-          ))}
-        </div>
-      )}
-    </div>
-  )
+  return <RelationshipsClient initial={relationships} />
 }

--- a/app/parent/client.tsx
+++ b/app/parent/client.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { AnimatePresence, motion } from 'framer-motion'
+import { createClient } from '@/src/lib/supabase/client'
+import { Conversation, Topic } from '@/src/lib/types'
+import topicsData from '@/src/data/topics.json'
+import { Button } from '@/src/components/ui/Button'
+import { APP_NAME } from '@/src/lib/constants'
+
+const topics = topicsData as Topic[]
+
+type State = 'code-entry' | 'welcome'
+
+export function ParentClient({ initialConversation }: { initialConversation: Conversation | null }) {
+  const [state, setState] = useState<State>(initialConversation ? 'welcome' : 'code-entry')
+  const [code, setCode] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [conversation, setConversation] = useState<Conversation | null>(initialConversation)
+  const router = useRouter()
+
+  const topic = conversation ? topics.find((t) => t.id === conversation.topic_id) : null
+
+  async function lookupCode(trimmed: string) {
+    setLoading(true)
+    setError('')
+
+    const supabase = createClient()
+    const { data, error: dbError } = await supabase
+      .from('conversations')
+      .select('*')
+      .eq('access_code', trimmed)
+      .neq('status', 'draft')
+      .single()
+
+    if (dbError || !data) {
+      setError("Code not found. Check with the person who invited you.")
+      setLoading(false)
+      return
+    }
+
+    setConversation(data)
+    setState('welcome')
+    setLoading(false)
+  }
+
+  async function handleCodeSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmed = code.trim().toUpperCase()
+    if (!trimmed) return
+    await lookupCode(trimmed)
+  }
+
+  function handleBegin() {
+    if (!conversation) return
+    router.push(`/parent/${conversation.id}`)
+  }
+
+  return (
+    <main className="parent-screen min-h-screen flex flex-col items-center justify-center px-6 py-16" style={{ background: '#fef8f0' }}>
+      <AnimatePresence mode="wait">
+        {state === 'code-entry' ? (
+          <motion.div
+            key="code-entry"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.3 }}
+            className="w-full max-w-sm"
+          >
+            <div className="text-center mb-8">
+              <div className="inline-flex items-center gap-2 mb-6 justify-center">
+                <div className="w-10 h-10 rounded-xl flex items-center justify-center text-white font-bold text-lg" style={{ background: '#d97706' }}>
+                  C
+                </div>
+                <span className="font-semibold text-xl" style={{ color: '#1a1512' }}>{APP_NAME}</span>
+              </div>
+              <h1 className="text-3xl font-bold mb-3" style={{ color: '#1a1512' }}>
+                Enter your access code
+              </h1>
+              <p style={{ color: '#6b5e52', fontSize: '1rem' }}>
+                Your family member shared a code with you to begin a conversation.
+              </p>
+            </div>
+
+            <div className="rounded-3xl p-8 shadow-sm" style={{ background: '#ffffff' }}>
+              <form onSubmit={handleCodeSubmit} className="space-y-5">
+                <div>
+                  <input
+                    type="text"
+                    value={code}
+                    onChange={(e) => setCode(e.target.value.toUpperCase())}
+                    placeholder="ABC123"
+                    maxLength={6}
+                    className="w-full text-center text-3xl font-bold tracking-[0.3em] py-4 px-6 rounded-2xl border-2 outline-none uppercase"
+                    style={{
+                      borderColor: error ? '#ef4444' : '#fbd08f',
+                      background: '#f6f3ef',
+                      color: '#1a1512',
+                    }}
+                    onFocus={(e) => { e.target.style.borderColor = '#f59e0b' }}
+                    onBlur={(e) => { if (!error) e.target.style.borderColor = '#fbd08f' }}
+                  />
+                  {error && (
+                    <p className="text-sm text-red-500 text-center mt-2">{error}</p>
+                  )}
+                </div>
+                <Button type="submit" disabled={loading || code.length < 4} className="w-full" size="lg">
+                  {loading ? 'Checking...' : "Let's Begin →"}
+                </Button>
+              </form>
+            </div>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="welcome"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.4 }}
+            className="w-full max-w-lg"
+          >
+            <div className="rounded-3xl p-10 shadow-sm mb-6 text-center" style={{ background: '#ffffff' }}>
+              <div
+                className="w-32 h-32 rounded-full mx-auto mb-6 flex items-center justify-center text-5xl"
+                style={{ background: '#fde8c8' }}
+              >
+                💬
+              </div>
+
+              <p className="text-sm font-medium mb-2" style={{ color: '#9a8a7d' }}>NEW INVITATION</p>
+              <h1 className="text-3xl font-bold mb-3" style={{ color: '#1a1512' }}>
+                You&apos;ve been invited to a conversation
+              </h1>
+
+              {topic && (
+                <>
+                  <p className="text-lg font-semibold mb-2" style={{ color: '#92400e' }}>
+                    {topic.title}
+                  </p>
+                  <p style={{ color: '#6b5e52', fontSize: '1rem' }} className="mb-8">
+                    {topic.description}
+                  </p>
+                </>
+              )}
+
+              <div className="flex gap-3 justify-center">
+                <Button size="lg" onClick={handleBegin}>
+                  Let&apos;s Begin →
+                </Button>
+              </div>
+            </div>
+
+            <div className="rounded-3xl p-8" style={{ background: '#ffffff' }}>
+              <h2 className="font-bold text-lg mb-6" style={{ color: '#1a1512' }}>How it works</h2>
+              <div className="grid grid-cols-3 gap-4">
+                {[
+                  { icon: '💬', title: '1. Read the question', desc: 'Each question is shown one at a time, in plain language.' },
+                  { icon: '✍️', title: '2. Share your thoughts', desc: 'Answer at your own pace. There are no wrong answers.' },
+                  { icon: '🎁', title: '3. Give a gift', desc: 'Your answers become a precious record for your family.' },
+                ].map(({ icon, title, desc }) => (
+                  <div key={title} className="text-center">
+                    <div className="text-3xl mb-2">{icon}</div>
+                    <p className="font-semibold text-sm mb-1" style={{ color: '#1a1512' }}>{title}</p>
+                    <p className="text-xs" style={{ color: '#9a8a7d' }}>{desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </main>
+  )
+}

--- a/app/parent/page.tsx
+++ b/app/parent/page.tsx
@@ -1,177 +1,29 @@
-'use client'
-
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { AnimatePresence, motion } from 'framer-motion'
-import { createClient } from '@/src/lib/supabase/client'
+import { createClient } from '@supabase/supabase-js'
 import { Conversation } from '@/src/lib/types'
-import topicsData from '@/src/data/topics.json'
-import { Topic } from '@/src/lib/types'
-import { Button } from '@/src/components/ui/Button'
-import { APP_NAME } from '@/src/lib/constants'
+import { ParentClient } from './client'
 
-const topics = topicsData as Topic[]
+export default async function ParentPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ code?: string }>
+}) {
+  const { code } = await searchParams
+  let initialConversation: Conversation | null = null
 
-type State = 'code-entry' | 'welcome'
-
-export default function ParentPage() {
-  const [state, setState] = useState<State>('code-entry')
-  const [code, setCode] = useState('')
-  const [error, setError] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [conversation, setConversation] = useState<Conversation | null>(null)
-  const router = useRouter()
-
-  const topic = conversation ? topics.find((t) => t.id === conversation.topic_id) : null
-
-  async function handleCodeSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    const trimmed = code.trim().toUpperCase()
-    if (!trimmed) return
-    setLoading(true)
-    setError('')
-
-    const supabase = createClient()
-    const { data, error: dbError } = await supabase
+  if (code) {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
+    )
+    const { data } = await supabase
       .from('conversations')
       .select('*')
-      .eq('access_code', trimmed)
+      .eq('access_code', code.trim().toUpperCase())
       .neq('status', 'draft')
       .single()
 
-    if (dbError || !data) {
-      setError("Code not found. Check with the person who invited you.")
-      setLoading(false)
-      return
-    }
-
-    setConversation(data)
-    setState('welcome')
-    setLoading(false)
+    initialConversation = data ?? null
   }
 
-  function handleBegin() {
-    if (!conversation) return
-    router.push(`/parent/${conversation.id}`)
-  }
-
-  return (
-    <main className="parent-screen min-h-screen flex flex-col items-center justify-center px-6 py-16" style={{ background: '#fef8f0' }}>
-      <AnimatePresence mode="wait">
-        {state === 'code-entry' ? (
-          <motion.div
-            key="code-entry"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -20 }}
-            transition={{ duration: 0.3 }}
-            className="w-full max-w-sm"
-          >
-            <div className="text-center mb-8">
-              <div className="inline-flex items-center gap-2 mb-6 justify-center">
-                <div className="w-10 h-10 rounded-xl flex items-center justify-center text-white font-bold text-lg" style={{ background: '#d97706' }}>
-                  C
-                </div>
-                <span className="font-semibold text-xl" style={{ color: '#1a1512' }}>{APP_NAME}</span>
-              </div>
-              <h1 className="text-3xl font-bold mb-3" style={{ color: '#1a1512' }}>
-                Enter your access code
-              </h1>
-              <p style={{ color: '#6b5e52', fontSize: '1rem' }}>
-                Your family member shared a code with you to begin a conversation.
-              </p>
-            </div>
-
-            <div className="rounded-3xl p-8 shadow-sm" style={{ background: '#ffffff' }}>
-              <form onSubmit={handleCodeSubmit} className="space-y-5">
-                <div>
-                  <input
-                    type="text"
-                    value={code}
-                    onChange={(e) => setCode(e.target.value.toUpperCase())}
-                    placeholder="ABC123"
-                    maxLength={6}
-                    className="w-full text-center text-3xl font-bold tracking-[0.3em] py-4 px-6 rounded-2xl border-2 outline-none uppercase"
-                    style={{
-                      borderColor: error ? '#ef4444' : '#fbd08f',
-                      background: '#f6f3ef',
-                      color: '#1a1512',
-                    }}
-                    onFocus={(e) => { e.target.style.borderColor = '#f59e0b' }}
-                    onBlur={(e) => { if (!error) e.target.style.borderColor = '#fbd08f' }}
-                  />
-                  {error && (
-                    <p className="text-sm text-red-500 text-center mt-2">{error}</p>
-                  )}
-                </div>
-                <Button type="submit" disabled={loading || code.length < 4} className="w-full" size="lg">
-                  {loading ? 'Checking...' : "Let's Begin →"}
-                </Button>
-              </form>
-            </div>
-          </motion.div>
-        ) : (
-          <motion.div
-            key="welcome"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -20 }}
-            transition={{ duration: 0.4 }}
-            className="w-full max-w-lg"
-          >
-            {/* Welcome card */}
-            <div className="rounded-3xl p-10 shadow-sm mb-6 text-center" style={{ background: '#ffffff' }}>
-              {/* Warm illustration placeholder */}
-              <div
-                className="w-32 h-32 rounded-full mx-auto mb-6 flex items-center justify-center text-5xl"
-                style={{ background: '#fde8c8' }}
-              >
-                💬
-              </div>
-
-              <p className="text-sm font-medium mb-2" style={{ color: '#9a8a7d' }}>NEW INVITATION</p>
-              <h1 className="text-3xl font-bold mb-3" style={{ color: '#1a1512' }}>
-                You&apos;ve been invited to a conversation
-              </h1>
-
-              {topic && (
-                <>
-                  <p className="text-lg font-semibold mb-2" style={{ color: '#92400e' }}>
-                    {topic.title}
-                  </p>
-                  <p style={{ color: '#6b5e52', fontSize: '1rem' }} className="mb-8">
-                    {topic.description}
-                  </p>
-                </>
-              )}
-
-              <div className="flex gap-3 justify-center">
-                <Button size="lg" onClick={handleBegin}>
-                  Let&apos;s Begin →
-                </Button>
-              </div>
-            </div>
-
-            {/* How it works */}
-            <div className="rounded-3xl p-8" style={{ background: '#ffffff' }}>
-              <h2 className="font-bold text-lg mb-6" style={{ color: '#1a1512' }}>How it works</h2>
-              <div className="grid grid-cols-3 gap-4">
-                {[
-                  { icon: '💬', title: '1. Read the question', desc: 'Each question is shown one at a time, in plain language.' },
-                  { icon: '✍️', title: '2. Share your thoughts', desc: 'Answer at your own pace. There are no wrong answers.' },
-                  { icon: '🎁', title: '3. Give a gift', desc: 'Your answers become a precious record for your family.' },
-                ].map(({ icon, title, desc }) => (
-                  <div key={title} className="text-center">
-                    <div className="text-3xl mb-2">{icon}</div>
-                    <p className="font-semibold text-sm mb-1" style={{ color: '#1a1512' }}>{title}</p>
-                    <p className="text-xs" style={{ color: '#9a8a7d' }}>{desc}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </main>
-  )
+  return <ParentClient initialConversation={initialConversation} />
 }

--- a/src/components/CopyLinkButton.tsx
+++ b/src/components/CopyLinkButton.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+
+const PARENT_BASE_URL = 'https://app.ourhearth.co/parent'
+
+export function CopyLinkButton({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(`${PARENT_BASE_URL}?code=${code}`)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      title="Copy link"
+      className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-xl border transition-colors whitespace-nowrap"
+      style={{
+        borderColor: copied ? '#059669' : '#e5ddd5',
+        color: copied ? '#059669' : '#6b5e52',
+        background: copied ? '#d1fae5' : '#f6f3ef',
+      }}
+    >
+      {copied ? (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+      {copied ? 'Copied!' : 'Copy link'}
+    </button>
+  )
+}

--- a/src/components/RelationshipPicker.tsx
+++ b/src/components/RelationshipPicker.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { track } from '@vercel/analytics'
-import { useEffect, useState } from 'react'
-import { createClient } from '@/src/lib/supabase/client'
+import { useState } from 'react'
 import { Relationship } from '@/src/lib/types'
 import { Button } from '@/src/components/ui/Button'
 
@@ -11,20 +10,11 @@ interface RelationshipPickerProps {
   onClose: () => void
   storyId?: string
   storyTitle?: string
+  relationships: Relationship[]
 }
 
-export function RelationshipPicker({ onConfirm, onClose, storyId, storyTitle }: RelationshipPickerProps) {
-  const [relationships, setRelationships] = useState<Relationship[]>([])
+export function RelationshipPicker({ onConfirm, onClose, storyId, storyTitle, relationships }: RelationshipPickerProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set())
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const supabase = createClient()
-    supabase.from('relationships').select('*').order('created_at').then(({ data }) => {
-      setRelationships(data ?? [])
-      setLoading(false)
-    })
-  }, [])
 
   function toggle(id: string) {
     setSelected((prev) => {
@@ -50,9 +40,7 @@ export function RelationshipPicker({ onConfirm, onClose, storyId, storyTitle }: 
         <h2 className="font-bold text-lg mb-1" style={{ color: '#1a1512' }}>Send to...</h2>
         <p className="text-sm mb-5" style={{ color: '#6b5e52' }}>Choose who to send this conversation to</p>
 
-        {loading ? (
-          <p className="text-sm" style={{ color: '#9a8a7d' }}>Loading...</p>
-        ) : relationships.length === 0 ? (
+        {relationships.length === 0 ? (
           <div className="text-center py-4">
             <p className="text-sm mb-3" style={{ color: '#9a8a7d' }}>No relationships yet.</p>
             <a href="/relationships" className="text-sm underline" style={{ color: '#d97706' }}>

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,10 +1,37 @@
 import { createServerClient } from "@supabase/ssr";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 
 export async function createClient() {
+  const isDev = process.env.DEV_BYPASS_AUTH === 'true';
+
+  if (isDev) {
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!serviceRoleKey) {
+      throw new Error('DEV_BYPASS_AUTH is true but SUPABASE_SERVICE_ROLE_KEY is not set in .env.local');
+    }
+
+    // Service role client bypasses RLS entirely — safe for local dev only
+    const client = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      serviceRoleKey,
+    );
+
+    const devUser = {
+      id: process.env.DEV_USER_ID!,
+      email: process.env.DEV_USER_EMAIL ?? 'dev@local.test',
+    };
+    client.auth.getUser = async () => ({
+      data: { user: devUser as any },
+      error: null,
+    });
+
+    return client;
+  }
+
   const cookieStore = await cookies();
 
-  const client = createServerClient(
+  return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
     {
@@ -24,17 +51,4 @@ export async function createClient() {
       },
     },
   );
-
-  if (process.env.DEV_BYPASS_AUTH === 'true') {
-    const devUser = {
-      id: process.env.DEV_USER_ID,
-      email: process.env.DEV_USER_EMAIL ?? "dev@local.test",
-    };
-    client.auth.getUser = async () => ({
-      data: { user: devUser as any },
-      error: null,
-    });
-  }
-
-  return client;
 }


### PR DESCRIPTION
Closes #21

## Summary
- Sent confirmation toast now shows a shareable link (`app.ourhearth.co/parent?code=XXXXXX`) with a one-tap copy button, plus a manual code fallback
- Conversations page: sent/in-progress cards include a copy link button alongside the access code
- `/parent` page: server-side code lookup eliminates the flash when opening a shared link — welcome screen renders immediately
- Reusable `CopyLinkButton` component with clipboard icon and transient "Copied!" state

## Also includes
- Fix: saving spinner stuck permanently when Supabase session is null on the relationships page
- Fix: local dev environment fully functional — service role key bypass in `server.ts`, relationships page refactored to server component + server actions so all DB operations work without a browser auth session

## Test plan
- [x] Send a conversation → confirm toast shows the shareable link and copy button works
- [ ] Open the copied link in a browser → confirm welcome screen appears immediately with no flash
- [ ] Navigate to `app.ourhearth.co/parent` manually and enter a code → confirm existing flow still works
- [ ] Conversations page → confirm copy link button appears on sent/in-progress cards
- [ ] Completed conversations → confirm no copy button, just "View responses →"

🤖 Generated with [Claude Code](https://claude.com/claude-code)