### PR TITLE
Add 'Create custom story' coming-soon card to library

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,3 +14,5 @@ DEV_BYPASS_AUTH=false
 DEV_USER_ID=
 DEV_USER_EMAIL=
 SUPABASE_SERVICE_ROLE_KEY=
+# Supabase DB password — needed for `supabase db push`. Find/reset under Project Settings → Database
+SUPABASE_DB_PASSWORD=

--- a/app/(app)/library/page.tsx
+++ b/app/(app)/library/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/src/lib/supabase/server'
 import topicsData from '@/src/data/topics.json'
 import { Topic } from '@/src/lib/types'
 import { TopicCard } from '@/src/components/TopicCard'
+import { CustomStoryCard } from '@/src/components/CustomStoryCard'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,15 +12,25 @@ export default async function LibraryPage() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 
-  const { data: conversations } = user
-    ? await supabase
-        .from('conversations')
-        .select('topic_id')
-        .eq('user_id', user.id)
-        .neq('status', 'draft')
-    : { data: [] }
+  const [{ data: conversations }, { data: interest }] = await Promise.all([
+    user
+      ? supabase
+          .from('conversations')
+          .select('topic_id')
+          .eq('user_id', user.id)
+          .neq('status', 'draft')
+      : Promise.resolve({ data: [] }),
+    user
+      ? supabase
+          .from('custom_story_interests')
+          .select('id')
+          .eq('user_id', user.id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+  ])
 
   const sentTopicIds = new Set((conversations ?? []).map((c) => c.topic_id))
+  const hasRegistered = interest !== null
 
   return (
     <div className="p-8">
@@ -36,6 +47,7 @@ export default async function LibraryPage() {
         {topics.map((topic) => (
           <TopicCard key={topic.id} topic={topic} hasSent={sentTopicIds.has(topic.id)} />
         ))}
+        <CustomStoryCard hasRegistered={hasRegistered} />
       </div>
     </div>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.98.0",
         "@vercel/analytics": "^2.0.1",
         "framer-motion": "^12.35.0",
+        "lucide-react": "^1.11.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -5067,6 +5068,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
+      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.98.0",
     "@vercel/analytics": "^2.0.1",
     "framer-motion": "^12.35.0",
+    "lucide-react": "^1.11.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/src/app/actions/registerCustomStoryInterest.ts
+++ b/src/app/actions/registerCustomStoryInterest.ts
@@ -1,0 +1,15 @@
+'use server'
+
+import { createClient } from '@/src/lib/supabase/server'
+
+export async function registerCustomStoryInterest() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const { error } = await supabase
+    .from('custom_story_interests')
+    .insert({ user_id: user.id })
+
+  return { error: error?.message ?? null }
+}

--- a/src/components/CustomStoryCard.tsx
+++ b/src/components/CustomStoryCard.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { Wand2, Check } from "lucide-react";
+import { track } from "@vercel/analytics";
+import { registerCustomStoryInterest } from "@/src/app/actions/registerCustomStoryInterest";
+
+interface CustomStoryCardProps {
+  hasRegistered: boolean;
+}
+
+export function CustomStoryCard({ hasRegistered }: CustomStoryCardProps) {
+  const [registered, setRegistered] = useState(hasRegistered);
+  const [pending, setPending] = useState(false);
+
+  async function handleRegisterInterest() {
+    if (registered || pending) return;
+    setPending(true);
+    setRegistered(true);
+    track("custom_story_interest_registered");
+    await registerCustomStoryInterest();
+    setPending(false);
+  }
+
+  return (
+    <div
+      className="rounded-3xl p-6"
+      style={{
+        background: "linear-gradient(135deg, #ede9fe 0%, #fef8f0 55%, #fde8c8 100%)",
+        border: "2px dashed #c4b5fd",
+      }}
+    >
+      <div className="mb-4">
+        <span
+          className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold"
+          style={{ background: "#7c3aed", color: "#ffffff" }}
+        >
+          Coming soon
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2.5 mb-3">
+        <Wand2 size={24} color="#7c3aed" strokeWidth={2} />
+        <h3 className="font-bold text-lg" style={{ color: "#4c1d95" }}>
+          Create custom story
+        </h3>
+      </div>
+
+      <p className="text-sm leading-relaxed mb-5" style={{ color: "#6b5e52" }}>
+        Have a conversation you&apos;d rather curate yourself? Use this to create a
+        custom conversation guided by our custom conversation genie!
+      </p>
+
+      <div className="border-t pt-4" style={{ borderColor: "#ddd6fe" }}>
+        {registered ? (
+          <span
+            className="inline-flex items-center gap-1.5 text-xs font-medium"
+            style={{ color: "#059669" }}
+          >
+            <Check size={13} />
+            Thanks for registering your interest. We&apos;ll be sure to let you know
+            when it&apos;s been built.
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={handleRegisterInterest}
+            disabled={pending}
+            className="text-xs font-medium underline underline-offset-2 transition-opacity hover:opacity-70"
+            style={{ color: "#7c3aed" }}
+          >
+            Interested? Let us know by clicking here
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260426000000_custom_story_interests.sql
+++ b/supabase/migrations/20260426000000_custom_story_interests.sql
@@ -1,0 +1,16 @@
+create table custom_story_interests (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (user_id)
+);
+
+alter table custom_story_interests enable row level security;
+
+create policy "Users can read own interest"
+  on custom_story_interests for select
+  using (auth.uid() = user_id);
+
+create policy "Users can register own interest"
+  on custom_story_interests for insert
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
Closes #22

## Summary
- Adds a visually distinct **Create custom story** card as the last item in the Conversation Library grid
- Card has a lavender-to-peach gradient background, dashed purple border, and a wand icon — clearly set apart from the regular topic cards
- Includes a one-click **"Interested? Let us know by clicking here"** button that registers the user's interest; swaps to a thank-you confirmation after clicking
- Interest is stored per-user in a new `custom_story_interests` table (one row max, enforced by unique constraint) with RLS policies
- Clicking the card itself does nothing — only the interest button is interactive
- Tracks `custom_story_interest_registered` via Vercel Analytics

## Test plan
- [x] `/library` shows the custom card last in the grid
- [x] Clicking "Interested? Let us know by clicking here" swaps to thank-you text immediately (optimistic)
- [x] Refreshing the page keeps the thank-you state (loaded from DB)
- [x] Clicking again does nothing (button disabled, unique constraint on DB)
- [x] Check `custom_story_interests` table in Supabase — one row per user
- [x] Clicking the card body does not navigate anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)