### PR TITLE
Fix remove relationship button (#28)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -8,6 +8,8 @@
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+# Supabase DB password — needed for `supabase db push`. Find/reset under Project Settings → Database
+SUPABASE_DB_PASSWORD=
 
 # ─── Local dev auth bypass ───────────────────────────────────────────────────
 # Set DEV_BYPASS_AUTH=true to skip Supabase auth checks when developing locally.
@@ -20,6 +22,3 @@ SUPABASE_SERVICE_ROLE_KEY=
 DEV_BYPASS_AUTH=false
 DEV_USER_ID=
 DEV_USER_EMAIL=
-SUPABASE_SERVICE_ROLE_KEY=
-# Supabase DB password — needed for `supabase db push`. Find/reset under Project Settings → Database
-SUPABASE_DB_PASSWORD=

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,16 +1,22 @@
-# Supabase — get these from the Supabase dashboard:
-# https://supabase.com/dashboard → select the "care-bears" project → Project Settings → API
+# ─── Supabase ────────────────────────────────────────────────────────────────
+# Supabase dashboard → select "care-bears" project → Project Settings → Data API
 #
-# Copy "Project URL" → NEXT_PUBLIC_SUPABASE_URL
+# Copy "Project URL"            → NEXT_PUBLIC_SUPABASE_URL
 # Copy "Publishable (anon) key" → NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY
+# Copy "service_role secret"    → SUPABASE_SERVICE_ROLE_KEY
 
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
 
-# Dev bypass — set DEV_BYPASS_AUTH=true to skip auth locally
-# DEV_USER_ID: your user ID from Supabase dashboard → Authentication → Users
-# SUPABASE_SERVICE_ROLE_KEY: Supabase dashboard → Project Settings → Data API → service_role secret
+# ─── Local dev auth bypass ───────────────────────────────────────────────────
+# Set DEV_BYPASS_AUTH=true to skip Supabase auth checks when developing locally.
+# This lets you access authenticated routes without going through the magic-link
+# flow. The service role key above is also required when this is enabled.
+#
+# DEV_USER_ID:    Supabase dashboard → Authentication → Users → copy your user ID
+# DEV_USER_EMAIL: the email address for that user (used for display only)
+
 DEV_BYPASS_AUTH=false
 DEV_USER_ID=
 DEV_USER_EMAIL=
-SUPABASE_SERVICE_ROLE_KEY=

--- a/README.md
+++ b/README.md
@@ -35,9 +35,21 @@ A guided conversation app that helps adult children have important talks with th
    cp .env.local.example .env.local
    ```
 
-   Open `.env.local` and fill in the two Supabase values. Get them from the [Supabase dashboard](https://supabase.com/dashboard) → select the **care-bears** project → **Project Settings** → **API**:
-   - Copy **Project URL** → `NEXT_PUBLIC_SUPABASE_URL`
-   - Copy **Publishable (anon) key** → `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`
+   Fill in the values in `.env.local`. All three Supabase keys are in the [Supabase dashboard](https://supabase.com/dashboard) → select the **care-bears** project → **Project Settings** → **Data API**:
+
+   | Variable | Where to find it |
+   |---|---|
+   | `NEXT_PUBLIC_SUPABASE_URL` | Project URL |
+   | `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` | Publishable (anon) key |
+   | `SUPABASE_SERVICE_ROLE_KEY` | service_role secret |
+
+   Then set up the dev auth bypass so you can use the app locally without going through the magic-link flow:
+
+   | Variable | Where to find it |
+   |---|---|
+   | `DEV_BYPASS_AUTH` | Set to `true` |
+   | `DEV_USER_ID` | Supabase dashboard → **Authentication → Users** → your user ID |
+   | `DEV_USER_EMAIL` | The email for that user |
 
 4. **Run the dev server**
    ```bash
@@ -64,7 +76,7 @@ The main app for the person initiating conversations.
 
 ### Entry Point 2: Parent Flow → `/parent`
 
-No login required. The parent uses a 6-character access code their child shares with them.
+No login required. The child shares a direct link (`/parent?code=XXXXXX`) or a 6-character code their parent can enter manually.
 
 | Step | Route                               | Description                                |
 | ---- | ----------------------------------- | ------------------------------------------ |

--- a/app/(app)/relationships/actions.ts
+++ b/app/(app)/relationships/actions.ts
@@ -8,15 +8,15 @@ export async function addRelationship(displayName: string, email: string) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return { error: 'Not authenticated' }
 
-  const { error } = await supabase.from('relationships').insert({
+  const { data, error } = await supabase.from('relationships').insert({
     user_id: user.id,
     display_name: displayName,
     email: email || '',
-  })
+  }).select().single()
 
-  if (error) return { error: error.message }
+  if (error) return { error: error.message, data: null }
   revalidatePath('/relationships')
-  return { error: null }
+  return { error: null, data }
 }
 
 export async function deleteRelationship(id: string) {

--- a/app/(app)/relationships/actions.ts
+++ b/app/(app)/relationships/actions.ts
@@ -24,7 +24,10 @@ export async function deleteRelationship(id: string) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return { error: 'Not authenticated' }
   const { error } = await supabase.from('relationships').delete().eq('id', id).eq('user_id', user.id)
-  if (error) return { error: error.message }
+  if (error) {
+    if (error.code === '23503') return { error: 'This person has conversations linked to them and can\'t be removed.' }
+    return { error: error.message }
+  }
   revalidatePath('/relationships')
   return { error: null }
 }

--- a/app/(app)/relationships/client.tsx
+++ b/app/(app)/relationships/client.tsx
@@ -25,6 +25,7 @@ export function RelationshipsClient({ initial }: { initial: Relationship[] }) {
     setAddError('')
     const result = await addRelationship(displayName, email)
     if (result.error) { setAddError(result.error); setSaving(false); return }
+    setRelationships((prev) => [...prev, result.data])
     setDisplayName('')
     setEmail('')
     setShowForm(false)

--- a/app/(app)/relationships/client.tsx
+++ b/app/(app)/relationships/client.tsx
@@ -9,19 +9,22 @@ import { addRelationship, deleteRelationship } from './actions'
 const QUICK_NAMES = ['Mom', 'Dad', 'Grandma', 'Grandpa', 'Partner']
 
 export function RelationshipsClient({ initial }: { initial: Relationship[] }) {
+  const [relationships, setRelationships] = useState(initial)
   const [showForm, setShowForm] = useState(false)
   const [displayName, setDisplayName] = useState('')
   const [email, setEmail] = useState('')
   const [saving, setSaving] = useState(false)
-  const [error, setError] = useState('')
+  const [addError, setAddError] = useState('')
+  const [deleteError, setDeleteError] = useState('')
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault()
     if (!displayName) return
     setSaving(true)
-    setError('')
+    setAddError('')
     const result = await addRelationship(displayName, email)
-    if (result.error) { setError(result.error); setSaving(false); return }
+    if (result.error) { setAddError(result.error); setSaving(false); return }
     setDisplayName('')
     setEmail('')
     setShowForm(false)
@@ -29,7 +32,10 @@ export function RelationshipsClient({ initial }: { initial: Relationship[] }) {
   }
 
   async function handleDelete(id: string) {
-    await deleteRelationship(id)
+    const result = await deleteRelationship(id)
+    if (result.error) { setDeleteError(result.error); return }
+    setRelationships((prev) => prev.filter((r) => r.id !== id))
+    setConfirmDeleteId(null)
   }
 
   return (
@@ -82,7 +88,7 @@ export function RelationshipsClient({ initial }: { initial: Relationship[] }) {
               className="w-full px-4 py-3 rounded-xl border text-sm outline-none"
               style={{ borderColor: '#e5ddd5', background: '#f6f3ef' }}
             />
-            {error && <p className="text-sm text-red-600">{error}</p>}
+            {addError && <p className="text-sm text-red-600">{addError}</p>}
             <div className="flex gap-3">
               <Button type="submit" disabled={saving || !displayName} size="sm">
                 {saving ? 'Saving...' : 'Save'}
@@ -95,26 +101,48 @@ export function RelationshipsClient({ initial }: { initial: Relationship[] }) {
         </Card>
       )}
 
-      {initial.length === 0 ? (
+      {deleteError && <p className="text-sm text-red-600 mb-4">{deleteError}</p>}
+
+      {relationships.length === 0 ? (
         <Card muted className="p-8 text-center">
           <p className="text-sm mb-4" style={{ color: '#9a8a7d' }}>No relationships yet.</p>
           <Button onClick={() => setShowForm(true)} size="sm">Add your first person</Button>
         </Card>
       ) : (
         <div className="space-y-3">
-          {initial.map((rel) => (
+          {relationships.map((rel) => (
             <Card key={rel.id} className="p-5 flex items-center justify-between shadow-sm">
               <div>
                 <p className="font-semibold" style={{ color: '#1a1512' }}>{rel.display_name}</p>
                 {rel.email && <p className="text-sm mt-0.5" style={{ color: '#9a8a7d' }}>{rel.email}</p>}
               </div>
-              <button
-                onClick={() => handleDelete(rel.id)}
-                className="text-xs underline"
-                style={{ color: '#c4a592' }}
-              >
-                Remove
-              </button>
+              {confirmDeleteId === rel.id ? (
+                <div className="flex items-center gap-3">
+                  <span className="text-xs" style={{ color: '#6b5e52' }}>Remove {rel.display_name}?</span>
+                  <button
+                    onClick={() => handleDelete(rel.id)}
+                    className="text-xs underline"
+                    style={{ color: '#c0392b' }}
+                  >
+                    Yes, remove
+                  </button>
+                  <button
+                    onClick={() => setConfirmDeleteId(null)}
+                    className="text-xs underline"
+                    style={{ color: '#9a8a7d' }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setConfirmDeleteId(rel.id)}
+                  className="text-xs underline"
+                  style={{ color: '#c4a592' }}
+                >
+                  Remove
+                </button>
+              )}
             </Card>
           ))}
         </div>

--- a/supabase/migrations/20260427000000_add_relationships_delete_policy.sql
+++ b/supabase/migrations/20260427000000_add_relationships_delete_policy.sql
@@ -1,0 +1,1 @@
+CREATE POLICY "rel_delete" ON relationships FOR DELETE USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

- **Root cause**: The `relationships` table had no `DELETE` RLS policy, so Supabase silently blocked every delete. The POST was firing correctly but 0 rows were ever affected.
- Added a migration (`20260427000000_add_relationships_delete_policy.sql`) with `CREATE POLICY "rel_delete" ON relationships FOR DELETE USING (auth.uid() = user_id)`.
- Added an inline confirmation step ("Remove X? / Yes, remove / Cancel") before the delete fires.
- Local `relationships` state now updates immediately on both add and delete — no manual refresh needed.
- FK violations (deleting a person with linked conversations) now return a friendly error: *"This person has conversations linked to them and can't be removed."* instead of the raw Postgres constraint message.

## Changes

- `supabase/migrations/20260427000000_add_relationships_delete_policy.sql` — new DELETE RLS policy
- `app/(app)/relationships/actions.ts` — return inserted row from `addRelationship`; map FK error code `23503` to friendly message
- `app/(app)/relationships/client.tsx` — local state for list, confirmation UI, separate add/delete error state

## Test plan

- [x] Apply the migration via `supabase db push` (or Supabase dashboard SQL editor)
- [x] Go to `/relationships`, click **Remove** — confirm the confirmation prompt appears
- [x] Click **Yes, remove** — relationship disappears immediately without a page refresh
- [x] Try removing a relationship that has linked conversations — confirm the friendly error message appears
- [x] Click **+ Add person**, fill in a name, click **Save** — new person appears immediately in the list without a refresh

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)