### PR TITLE
Book story renderer for Getting to Know Me — SHORT

### DIFF
--- a/src/components/BookStory/index.tsx
+++ b/src/components/BookStory/index.tsx
@@ -201,6 +201,36 @@ export default function BookStory({
               </em>,
             );
           });
+      } else if (seg.t === "qt") {
+        const quoteWords = seg.v.trim().split(/\s+/);
+        nodes.push(
+          <span key={prefix} style={{ display: "block", marginBottom: "0.25em" }}>
+            {quoteWords.map((word, j) => (
+              <em
+                key={`${prefix}-q-${j}`}
+                className="hb-word"
+                style={{ fontStyle: "italic", color: "#f08838" }}
+              >
+                {word}{" "}
+              </em>
+            ))}
+            {seg.attr && (
+              <span
+                className="hb-word"
+                style={{
+                  display: "block",
+                  fontSize: "0.72em",
+                  fontStyle: "italic",
+                  color: "rgba(42,24,6,0.42)",
+                  marginTop: "0.2em",
+                  letterSpacing: "0.04em",
+                }}
+              >
+                — {seg.attr}
+              </span>
+            )}
+          </span>,
+        );
       } else if (seg.t === "bl") {
         const initVal = answersRef.current[seg.key] ?? "";
         nodes.push(

--- a/src/components/BookStoryPreview/index.tsx
+++ b/src/components/BookStoryPreview/index.tsx
@@ -25,6 +25,27 @@ function renderParaSegs(segs: BookSeg[], answers?: Record<string, string>) {
         </em>
       );
     }
+    if (seg.t === "qt") {
+      return (
+        <span key={i} style={{ display: "block", marginBottom: "0.25em" }}>
+          <em style={{ fontStyle: "italic", color: "#f08838" }}>{seg.v} </em>
+          {seg.attr && (
+            <span
+              style={{
+                display: "block",
+                fontSize: "0.72em",
+                fontStyle: "italic",
+                color: "rgba(42,24,6,0.42)",
+                marginTop: "0.12em",
+                letterSpacing: "0.04em",
+              }}
+            >
+              — {seg.attr}
+            </span>
+          )}
+        </span>
+      );
+    }
     if (seg.t === "bl") {
       const filled = answers?.[seg.key];
       return (

--- a/src/data/stories/getting-to-know-me-short.ts
+++ b/src/data/stories/getting-to-know-me-short.ts
@@ -1,6 +1,7 @@
 export type BookSeg =
   | { t: 'tx'; v: string }
   | { t: 'it'; v: string }
+  | { t: 'qt'; v: string; attr?: string }
   | { t: 'br' }
   | { t: 'bl'; key: string; ph: string; multi?: boolean; italic?: boolean }
 
@@ -12,8 +13,8 @@ export const STORY: BookSpread[] = [
   {
     L: {
       segs: [
-        { t: 'it', v: '"Ring around the rosie, a pocket full of posies, ashes, ashes, we all fall down."' },
-        { t: 'it', v: "We'll get to the ashes part. First — let's talk about life." },
+        { t: 'qt', v: '“Tell me, what is it you plan to do with your one wild and precious life?”', attr: 'Mary Oliver' },
+        { t: 'tx', v: "Good question, Mary. Let’s find out." },
         { t: 'br' },
         { t: 'tx', v: "So… you want to know if I want to be buried, cremated, or sent off viking style? There's a whole side of me you'll get to know before that." },
       ],


### PR DESCRIPTION
## Summary
- Adds a book/journal-style interactive story renderer (`BookStory`) for the "Getting to Know Me — SHORT" topic with page-turn animation, staggered word-fade reveal, and fill-in-the-blank fields saved to Supabase
- Replaces the butterfly animation with a staggered word-fade on the parent conversation flow
- Replaces the nursery rhyme opening quote with a Mary Oliver quote: *"Tell me, what is it you plan to do with your one wild and precious life?"* — with an attributed "— Mary Oliver" byline and a response line below it

## Test plan
- [ ] "Getting to Know Me — SHORT" appears in the library and topic detail page
- [ ] Conversation preview shows the Mary Oliver quote with attribution and correct orange italic styling
- [ ] Opening the story as a parent renders the book view with page-turn animation
- [ ] Fill-in-the-blank fields save answers correctly
- [ ] Staggered word-fade plays on each page turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)